### PR TITLE
Add password-protected login page

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Medication List</title>
   <link rel="stylesheet" href="styles.css">
+  <script>
+    if (sessionStorage.getItem('loggedIn') !== 'true') {
+      window.location.href = 'login.html';
+    }
+  </script>
 </head>
 <body>
   <div class="container">

--- a/login.html
+++ b/login.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Login</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <div class="container">
+    <h1>Login</h1>
+    <form id="login-form">
+      <label for="password">Password:</label>
+      <input type="password" id="password" required>
+      <button type="submit">Enter</button>
+      <p id="error" class="error"></p>
+    </form>
+  </div>
+  <script src="login.js"></script>
+</body>
+</html>

--- a/login.js
+++ b/login.js
@@ -1,0 +1,14 @@
+const form = document.getElementById('login-form');
+const passwordInput = document.getElementById('password');
+const errorEl = document.getElementById('error');
+
+form.addEventListener('submit', (e) => {
+  e.preventDefault();
+  const password = passwordInput.value;
+  if (password === 'medlist123') {
+    sessionStorage.setItem('loggedIn', 'true');
+    window.location.href = 'index.html';
+  } else {
+    errorEl.textContent = 'Incorrect password';
+  }
+});

--- a/styles.css
+++ b/styles.css
@@ -87,6 +87,10 @@ h2 {
   text-decoration: underline;
 }
 
+.error {
+  color: red;
+}
+
 @media (max-width: 600px) {
   body {
     font-size: 18px;


### PR DESCRIPTION
## Summary
- Redirect unauthenticated visitors to a new login page
- Add login page and script that validates a simple password
- Style error message for invalid login attempts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68903dd6e3d083319e3d3619a830d9cd