### PR TITLE
Implement sticky medication header

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
 </head>
 <body>
   <div class="container">
-    <h1>Medication List</h1>
+    <h1 id="sticky-header">Medication List</h1>
     <section id="patient"></section>
     <section id="physicians"></section>
     <section>

--- a/script.js
+++ b/script.js
@@ -72,7 +72,7 @@ function renderMedications() {
     const li = document.createElement('li');
     li.className = 'med-item';
     li.innerHTML = `<details>
-        <summary>${med.number}. <a href="${link}" target="_blank" rel="noopener noreferrer">${med.name}</a></summary>
+        <summary data-med-name="${med.name}">${med.number}. <a href="${link}" target="_blank" rel="noopener noreferrer">${med.name}</a></summary>
         <div class="med-details">
           <p><strong>Directions:</strong> ${med.directions}</p>
           <p><strong>Commonly known as:</strong> ${med.common}</p>
@@ -80,6 +80,19 @@ function renderMedications() {
           <p><strong>Treatment:</strong> ${med.treatment}</p>
         </div>
       </details>`;
+    const details = li.querySelector('details');
+    const summary = details.querySelector('summary');
+    details.addEventListener('toggle', () => {
+      if (details.open) {
+        document.querySelectorAll('.med-item details[open]').forEach(d => {
+          if (d !== details) {
+            d.open = false;
+          }
+        });
+        const header = document.getElementById('sticky-header');
+        header.textContent = summary.dataset.medName;
+      }
+    });
     list.appendChild(li);
   });
 }

--- a/styles.css
+++ b/styles.css
@@ -25,6 +25,15 @@ h2 {
   color: var(--primary);
 }
 
+#sticky-header {
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  background: var(--light-bg);
+  margin: 0;
+  padding: 1rem 0;
+}
+
 h2 {
   color: var(--accent);
 }


### PR DESCRIPTION
## Summary
- Keep Medication List title fixed at the top of the page
- Update sticky header to display the selected medication name when its details are opened

## Testing
- `npm test` *(fails: could not find package.json)*
- `npx prettier -c index.html script.js styles.css` *(fails: code style issues found)*

------
https://chatgpt.com/codex/tasks/task_e_689043bafc988331b9e08ab57b7de098