### PR TITLE
Open medication links in same window

### DIFF
--- a/script.js
+++ b/script.js
@@ -74,7 +74,7 @@ function renderMedications() {
     const li = document.createElement('li');
     li.className = 'med-item';
     li.innerHTML = `<details>
-        <summary data-med-name="${med.name}">${med.number}. <a href="${link}" target="_blank" rel="noopener noreferrer">${med.name}</a></summary>
+        <summary data-med-name="${med.name}">${med.number}. <a href="${link}">${med.name}</a></summary>
         <div class="med-details">
           <p><strong>Directions:</strong> ${med.directions}</p>
           <p><strong>Commonly known as:</strong> ${med.common}</p>


### PR DESCRIPTION
## Summary
- remove `target="_blank"` to open medication links in the same tab

## Testing
- `npm test` (fails: package.json missing)


------
https://chatgpt.com/codex/tasks/task_e_689046a205608331a1b0802a341d92c2