### PR TITLE
Lighten medication dropdown background

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -126,7 +126,7 @@ strong {
   padding: 1rem;
   font-weight: 700;
   cursor: pointer;
-  background: #b3e5fc;
+  background: #e3f2fd;
   color: #ff4081; /* changed from var(--accent) to a brighter color */
   transition: background 0.3s ease;
 }
@@ -142,7 +142,7 @@ strong {
 }
 
 .med-item summary:hover {
-  background: #81d4fa;
+  background: #bbdefb;
 }
 
 .med-details {
@@ -171,8 +171,12 @@ strong {
   }
 
   .med-item summary {
-    background: #01579b;
+    background: #0277bd;
     color: #ff4081; /* changed from #80deea to a brighter color */
+  }
+
+  .med-item summary:hover {
+    background: #0288d1;
   }
 
   .med-item summary a {


### PR DESCRIPTION
## Summary
- use lighter blue for medication dropdown summary and hover to make text stand out
- adjust dark mode dropdown colors for better contrast

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68905af8b8488331ad874fd12e90a18f