### PR TITLE
Align drug info labels with invisible table layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,8 +29,14 @@
             <!-- Uploaded image will appear here -->
           </div>
           <div class="drug-details">
-            <p><strong>Drug Name:</strong> Aspirin</p>
-            <p><strong>Dosage:</strong> 100mg</p>
+            <div class="info-row">
+              <span class="info-title">Drug Name:</span>
+              <span class="info-data">Aspirin</span>
+            </div>
+            <div class="info-row">
+              <span class="info-title">Dosage:</span>
+              <span class="info-data">100mg</span>
+            </div>
             <!-- Additional drug info... -->
           </div>
         </div>

--- a/script.js
+++ b/script.js
@@ -175,10 +175,22 @@ function renderMedications() {
         <summary data-med-name="${med.name}">${med.number}. <a href="${link}">${med.name}</a></summary>
         <div class="med-details">
           <div class="drug-info-left">
-            <p><strong>Directions:</strong> ${med.directions}</p>
-            <p><strong>Commonly known as:</strong> ${med.common}</p>
-            <p><strong>RX:</strong> ${med.rx}</p>
-            <p><strong>Treatment:</strong> ${med.treatment}</p>
+            <div class="info-row">
+              <span class="info-title">Directions:</span>
+              <span class="info-data">${med.directions}</span>
+            </div>
+            <div class="info-row">
+              <span class="info-title">Commonly known as:</span>
+              <span class="info-data">${med.common}</span>
+            </div>
+            <div class="info-row">
+              <span class="info-title">RX:</span>
+              <span class="info-data">${med.rx}</span>
+            </div>
+            <div class="info-row">
+              <span class="info-title">Treatment:</span>
+              <span class="info-data">${med.treatment}</span>
+            </div>
           </div>
           <div class="med-pill-upload">
             <div class="pill-image-box" id="pill-image-box-${med.number}">

--- a/styles.css
+++ b/styles.css
@@ -150,6 +150,30 @@ strong {
   background: var(--light-bg);
 }
 
+.drug-info-left,
+.drug-details {
+  display: table;
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.info-row {
+  display: table-row;
+}
+
+.info-title,
+.info-data {
+  display: table-cell;
+  padding: 0.25rem 0;
+}
+
+.info-title {
+  font-weight: 700;
+  color: var(--primary);
+  padding-right: 1rem;
+  white-space: nowrap;
+}
+
 @media (prefers-color-scheme: dark) {
   body {
     background: linear-gradient(135deg, #0d47a1, #006064);


### PR DESCRIPTION
## Summary
- replace drug detail paragraphs with table-style rows for consistent label/data alignment
- adjust medication rendering to use new rows
- style drug info container with invisible table CSS to prevent overlap

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890efc68f748331ace0c6fcce9e0fc1