### PR TITLE
fix: prevent horizontal scrolling on mobile

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -7,12 +7,32 @@
   --card-bg: rgba(255, 255, 255, 0.05);
 }
 
+html,
+body {
+  margin: 0;
+  padding: 0;
+  overflow-x: hidden;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+img,
+div,
+section,
+button,
+input {
+  max-width: 100%;
+  width: 100%;
+}
+
 body {
   font-family: "Nunito", sans-serif;
   font-size: 18px;
   font-weight: 300;
-  margin: 0;
-  padding: 0;
   background: linear-gradient(135deg, var(--bg-start), var(--bg-end));
   color: var(--text-color);
 }
@@ -84,10 +104,11 @@ h2 {
   flex: 1;
 }
 
-.physician-map {
-  width: 200px;
-  margin-left: 1rem;
-}
+  .physician-map {
+    width: 100%;
+    max-width: 200px;
+    margin-left: 1rem;
+  }
 
 .physician-map iframe {
   width: 100%;
@@ -287,6 +308,7 @@ details[open] .med-details {
   z-index: 1100;
   padding: 0.5rem 1rem;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
+  width: auto;
 }
 
 .nav-toggle:hover {
@@ -336,10 +358,11 @@ details[open] .med-details {
   font-size: 0.875rem;
 }
 
-#qr-container img {
-  width: 80px;
-  height: 80px;
-}
+  #qr-container img {
+    width: 100%;
+    max-width: 80px;
+    height: 80px;
+  }
 
 
 body.light-mode {
@@ -507,7 +530,8 @@ body.light-mode {
   position: fixed;
   top: 0;
   left: 0;
-  width: 250px;
+  width: 100%;
+  max-width: 250px;
   height: 100%;
   background: #102840;
   color: #fff;
@@ -532,6 +556,7 @@ body.light-mode {
   border-radius: 4px;
   font-size: 1rem;
   cursor: pointer;
+  width: auto;
 }
 
 /* Updated styles for menu dropdown and button */
@@ -552,6 +577,7 @@ body.light-mode {
   font-size: 1rem;
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
+  width: auto;
 }
 
 #nav-toggle:hover {


### PR DESCRIPTION
## Summary
- disable horizontal scrolling by hiding overflow and normalizing box sizing
- constrain wide elements to screen width and convert fixed pixel widths to responsive
- restore menu button to natural width so it no longer stretches across the screen

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689159cf50f88331b3381816b4d946c4