### PR TITLE
Move print and dark mode controls to footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,20 +39,10 @@
       </ul>
     </nav>
     <div class="container">
-      <header class="page-header">
-        <h1 id="sticky-header">Medication List</h1>
-        <div class="header-actions">
-          <button id="print-btn" aria-label="Print list">
-            <i class="fas fa-print"></i>
-            <span>Print</span>
-          </button>
-          <button id="mode-toggle" aria-label="Toggle light or dark mode">
-            <i class="fas fa-moon"></i>
-            <span>Dark Mode</span>
-          </button>
+        <header class="page-header">
+          <h1 id="sticky-header">Medication List</h1>
           <div id="qr-container"></div>
-        </div>
-      </header>
+        </header>
 
       <section id="patient"></section>
       <section id="physicians"></section>
@@ -60,7 +50,17 @@
         <h2><i class="fas fa-pills"></i> Medications</h2>
         <ul id="med-list" class="med-list"></ul>
       </section>
-    </div>
-    <script src="script.js"></script>
-  </body>
-</html>
+      </div>
+      <footer class="page-footer">
+        <button id="print-btn" aria-label="Print list">
+          <i class="fas fa-print"></i>
+          <span>Print</span>
+        </button>
+        <button id="mode-toggle" aria-label="Toggle light or dark mode">
+          <i class="fas fa-moon"></i>
+          <span>Dark Mode</span>
+        </button>
+      </footer>
+      <script src="script.js"></script>
+    </body>
+  </html>

--- a/print.css
+++ b/print.css
@@ -6,7 +6,7 @@ body * {
 .container, .container * {
   visibility: visible;
 }
-header, nav, .header-actions, #qr-container, #sidebar, #sidebar-toggle, .nav-toggle, #mode-toggle, #print-btn {
+header, nav, .page-footer, #qr-container, #sidebar, #sidebar-toggle, .nav-toggle, #mode-toggle, #print-btn {
   display: none !important;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -329,16 +329,14 @@ details[open] .med-details {
 }
 
 
-.header-actions {
+.page-footer {
   display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-  align-items: center;
   justify-content: center;
+  gap: 0.5rem;
+  padding: 1rem 0;
 }
 
-
-.header-actions button {
+.page-footer button {
   display: flex;
   align-items: center;
   gap: 0.25rem;
@@ -346,7 +344,6 @@ details[open] .med-details {
   border: none;
   border-radius: 8px;
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
-
   color: #fff;
   padding: 0.5rem 0.75rem;
   min-width: 130px;
@@ -355,25 +352,25 @@ details[open] .med-details {
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.header-actions button:hover {
+.page-footer button:hover {
   transform: translateY(-2px);
   box-shadow: 0 6px 8px rgba(0, 0, 0, 0.4);
 }
 
-.header-actions button:active {
+.page-footer button:active {
   transform: translateY(0);
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
 }
 
-.header-actions button span {
+.page-footer button span {
   font-size: 0.875rem;
 }
 
-  #qr-container img {
-    width: 100%;
-    max-width: 80px;
-    height: 80px;
-  }
+#qr-container img {
+  width: 100%;
+  max-width: 80px;
+  height: 80px;
+}
 
 
 body.light-mode {
@@ -389,7 +386,7 @@ body.light-mode {
     color: #000000;
   }
   .nav-menu,
-  .header-actions,
+  .page-footer,
   .nav-toggle,
   #qr-container {
     display: none;


### PR DESCRIPTION
## Summary
- Relocate print and dark mode buttons from header to a new footer
- Add footer styling for side-by-side buttons and adjust print styles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68916d84163c8331a961f422b9416b15