### PR TITLE
Reload page after printing to reset view

### DIFF
--- a/script.js
+++ b/script.js
@@ -300,13 +300,14 @@ function attachToggleListeners() {
 function expandAllAndPrint() {
   const details = document.querySelectorAll('details');
   details.forEach((d) => (d.open = true));
-  window.addEventListener(
-    'afterprint',
-    () => {
-      details.forEach((d) => (d.open = false));
-    },
-    { once: true }
-  );
+  const handleDone = () => {
+    details.forEach((d) => (d.open = false));
+    window.removeEventListener('focus', handleDone);
+    window.removeEventListener('afterprint', handleDone);
+    window.location.reload();
+  };
+  window.addEventListener('afterprint', handleDone, { once: true });
+  window.addEventListener('focus', handleDone, { once: true });
   window.print();
 }
 


### PR DESCRIPTION
## Summary
- Auto-collapse medication boxes and reload the page once printing finishes
- Ensure the refresh waits until the print dialog closes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891852c66dc8331b2017ca98fb60709