### PR TITLE
Add printable medication list view

### DIFF
--- a/print.css
+++ b/print.css
@@ -1,77 +1,83 @@
-/* Updated print styles for medication list */
-
-body * {
-  visibility: hidden;
-}
-.container, .container * {
-  visibility: visible;
-}
-header, nav, .page-footer, #qr-container, #sidebar, #sidebar-toggle, .nav-toggle, #mode-toggle, #print-btn {
-  display: none !important;
-}
-
-.container {
-  width: 100% !important;
-  max-width: none !important;
-  margin: 0 !important;
-  padding: 0.5in !important;
-  background: #fff !important;
-  color: #000 !important;
-  font-family: Times New Roman, Times, serif !important;
-}
-
-#med-list {
+body {
   margin: 0;
-  padding: 0;
+  background: #fff;
+  color: #000;
+  font-family: Arial, sans-serif;
 }
 
-.med-item {
-  border-bottom: 2px solid #000;
-  margin-bottom: 0.5em;
-  padding-bottom: 0.5em;
+.print-container {
+  max-width: 8.5in;
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+.print-header {
+  text-align: center;
+  margin-bottom: 1rem;
+}
+
+.patient-info {
+  font-size: 0.9rem;
+  margin-top: 0.5rem;
+}
+
+.med-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+}
+
+.medication-card {
+  border: 1px solid #000;
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
   page-break-inside: avoid;
 }
 
-.med-item details,
-.med-item[open] {
-  display: block !important;
-}
-
-.med-item summary {
-  display: none !important;
-}
-
-.med-details {
-  display: flex;
-  flex-direction: row;
-  align-items: flex-start;
-  gap: 1em;
-}
-
-.med-number {
-  font-size: 2em;
+.medication-card .med-name {
   font-weight: bold;
-  margin-right: 0.5em;
-  min-width: 2em;
-  text-align: right;
+  font-size: 1.1rem;
 }
 
-.drug-info-left {
-  flex: 1;
+.medication-card .dosage {
+  font-weight: normal;
 }
 
-.info-title {
+.med-detail {
+  margin-top: 0.25rem;
+  font-size: 0.9rem;
+}
+
+.label {
   font-weight: bold;
+  font-size: 0.85rem;
 }
 
-.info-data {
-  margin-left: 0.5em;
+.print-button {
+  display: block;
+  margin: 1rem auto;
+  padding: 0.5rem 1rem;
 }
 
-.treatment {
-  font-style: italic;
-}
-
-@page {
-  margin: 0.5in;
+@media print {
+  body * {
+    visibility: hidden;
+  }
+  #printable-area,
+  #printable-area * {
+    visibility: visible;
+  }
+  #printable-area {
+    position: absolute;
+    left: 0;
+    top: 0;
+  }
+  .print-button {
+    display: none;
+  }
+  @page {
+    size: 8.5in 11in;
+    margin: 0.5in;
+  }
 }

--- a/print.html
+++ b/print.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Printable Medication List</title>
+    <link rel="stylesheet" href="print.css" />
+  </head>
+  <body>
+    <div id="printable-area" class="print-container">
+      <header class="print-header">
+        <h1 id="print-title"></h1>
+        <div id="patient-info" class="patient-info"></div>
+      </header>
+      <section id="medications" class="med-grid"></section>
+    </div>
+    <button id="print-btn" class="print-button">Print</button>
+    <script src="print.js"></script>
+  </body>
+</html>

--- a/print.js
+++ b/print.js
@@ -1,0 +1,33 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const meds = JSON.parse(localStorage.getItem('medications')) || [];
+  const patient = JSON.parse(localStorage.getItem('patient')) || null;
+
+  const titleEl = document.getElementById('print-title');
+  const today = new Date();
+  const dateStr = `${today.getMonth() + 1}/${today.getDate()}/${today.getFullYear()}`;
+  titleEl.textContent = `Medication List as of ${dateStr}`;
+
+  if (patient) {
+    const pInfo = document.getElementById('patient-info');
+    pInfo.innerHTML = `<strong>${patient.name}</strong><br>${patient.address}<br>${patient.phone}`;
+  }
+
+  const container = document.getElementById('medications');
+  meds.forEach((m) => {
+    const card = document.createElement('div');
+    card.className = 'medication-card';
+    card.innerHTML = `
+      <div class="med-number">${m.number}.</div>
+      <div class="med-name">${m.name} <span class="dosage">${m.dosage}</span></div>
+      <div class="med-detail"><span class="label">Commonly known as:</span> <span class="value">${m.common}</span></div>
+      <div class="med-detail"><span class="label">RX:</span> <span class="value">${m.rx}</span></div>
+      <div class="med-detail"><span class="label">Instructions:</span> <span class="value">${m.instructions}</span></div>
+      <div class="med-detail"><span class="label">Treatment:</span> <span class="value">${m.treatment}</span></div>
+    `;
+    container.appendChild(card);
+  });
+
+  document.getElementById('print-btn').addEventListener('click', () => {
+    window.print();
+  });
+});

--- a/script.js
+++ b/script.js
@@ -297,21 +297,6 @@ function attachToggleListeners() {
   });
 }
 
-function expandAllAndPrint() {
-  const details = document.querySelectorAll('details');
-  details.forEach((d) => (d.open = true));
-  const handleDone = () => {
-    details.forEach((d) => (d.open = false));
-    window.removeEventListener('focus', handleDone);
-    window.removeEventListener('afterprint', handleDone);
-    window.location.reload();
-  };
-  window.addEventListener('afterprint', handleDone, { once: true });
-  window.addEventListener('focus', handleDone, { once: true });
-
-  window.print();
-}
-
 function initUI() {
   const modeBtn = document.getElementById('mode-toggle');
   modeBtn.addEventListener('click', () => {
@@ -328,7 +313,20 @@ function initUI() {
 
   // Attach to print button
   document.getElementById('print-btn').addEventListener('click', () => {
-    expandAllAndPrint();
+    const meds = medications.map(
+      ({ number, name, dosage, common, rx, instructions, treatment }) => ({
+        number,
+        name,
+        dosage,
+        common,
+        rx,
+        instructions,
+        treatment,
+      })
+    );
+    localStorage.setItem('medications', JSON.stringify(meds));
+    localStorage.setItem('patient', JSON.stringify(patient));
+    window.open('print.html', '_blank');
   });
 
   const qr = document.createElement('img');


### PR DESCRIPTION
## Summary
- add dedicated `print.html` page that formats medication data and patient details for printing
- store medication and patient data in localStorage and open printable view via the main Print button
- style printable view with white background, boxed entries, and print-only visibility rules

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689237a62c208331b1439315594f602a