### PR TITLE
Enhance print-page buttons for usability

### DIFF
--- a/print.css
+++ b/print.css
@@ -58,22 +58,28 @@ body {
 .controls {
   display: flex;
   justify-content: center;
+  align-items: center;
   gap: 1rem;
-  margin: 1rem 0;
+  margin: 1.5rem 0;
 }
 
 .action-button {
-  padding: 0.5rem 1.5rem;
-  font-size: 1rem;
-  background: linear-gradient(#f0f0f0, #d9d9d9);
-  border: 1px solid #999;
-  border-radius: 4px;
-  box-shadow: 0 4px #bbb;
+  width: 200px;
+  padding: 0.75rem 2rem;
+  font-size: 1.1rem;
+  color: #fff;
+  background: linear-gradient(#6cb2eb, #2b6cb0);
+  border: 1px solid #2b6cb0;
+  border-radius: 6px;
+  box-shadow: 0 4px 0 #1a4971;
   cursor: pointer;
+  text-decoration: none;
+  text-align: center;
+  display: inline-block;
 }
 
 .action-button:active {
-  box-shadow: 0 2px #bbb;
+  box-shadow: 0 2px 0 #1a4971;
   transform: translateY(2px);
 }
 

--- a/print.html
+++ b/print.html
@@ -8,8 +8,8 @@
   </head>
   <body>
     <div class="controls top-controls">
-      <button class="action-button print-btn">Print</button>
-      <button class="action-button home-btn">Go Back to Homepage</button>
+      <button type="button" class="action-button print-btn">Print</button>
+      <button type="button" class="action-button home-btn">Go Back to Homepage</button>
     </div>
     <div id="printable-area" class="print-container">
       <header class="print-header">
@@ -19,8 +19,8 @@
       <section id="medications" class="med-grid"></section>
     </div>
     <div class="controls bottom-controls">
-      <button class="action-button print-btn">Print</button>
-      <button class="action-button home-btn">Go Back to Homepage</button>
+      <button type="button" class="action-button print-btn">Print</button>
+      <button type="button" class="action-button home-btn">Go Back to Homepage</button>
     </div>
     <script src="print.js"></script>
   </body>

--- a/print.js
+++ b/print.js
@@ -27,13 +27,16 @@ document.addEventListener('DOMContentLoaded', () => {
     container.appendChild(card);
   });
 
+  const handlePrint = () => window.print();
+  const goHome = () => {
+    window.location.href = 'index.html';
+  };
+
   document.querySelectorAll('.print-btn').forEach((btn) =>
-    btn.addEventListener('click', () => window.print())
+    btn.addEventListener('click', handlePrint)
   );
 
   document.querySelectorAll('.home-btn').forEach((btn) =>
-    btn.addEventListener('click', () => {
-      window.location.href = 'index.html';
-    })
+    btn.addEventListener('click', goHome)
   );
 });


### PR DESCRIPTION
## Summary
- Hook up print and home buttons to print the page and navigate back to the index
- Rework button styles: centered top and bottom controls, uniform sizing, larger 3D blue buttons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689248cbb58483318055892685de295e