### PR TITLE
Move print to nav and size print buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,6 +35,7 @@
       <ul>
         <li><a href="#patient"><i class="fas fa-user"></i> Patient Info</a></li>
         <li><a href="#physicians"><i class="fas fa-user-md"></i> Physician Info</a></li>
+        <li><a href="#" id="print-btn"><i class="fas fa-print"></i> Print List</a></li>
         <li><a href="#medications"><i class="fas fa-pills"></i> Medications</a></li>
       </ul>
     </nav>
@@ -52,10 +53,6 @@
       </section>
       </div>
       <footer class="page-footer">
-        <button id="print-btn" aria-label="Print list">
-          <i class="fas fa-print"></i>
-          <span>Print</span>
-        </button>
         <button id="mode-toggle" aria-label="Toggle light or dark mode">
           <i class="fas fa-moon"></i>
           <span>Dark Mode</span>

--- a/print.css
+++ b/print.css
@@ -76,6 +76,8 @@ body {
   text-decoration: none;
   text-align: center;
   display: inline-block;
+  white-space: nowrap;
+  box-sizing: border-box;
 }
 
 .action-button:active {

--- a/script.js
+++ b/script.js
@@ -312,7 +312,8 @@ function initUI() {
   });
 
   // Attach to print button
-  document.getElementById('print-btn').addEventListener('click', () => {
+  document.getElementById('print-btn').addEventListener('click', (e) => {
+    e.preventDefault();
     const meds = medications.map(
       ({ number, name, dosage, common, rx, instructions, treatment }) => ({
         number,


### PR DESCRIPTION
## Summary
- Move Print List action into the navigation menu for easier access
- Remove footer print button and keep mode toggle only
- Make print page buttons consistent in size

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892687115d483319723106e002deb02