### PR TITLE
Change default password to 1952

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 MedList is a responsive, client-side web app that displays a patient's medications along with physician and contact information.
 
 ## Features
-- Password-protected login (default password `drugBD`)
+- Password-protected login (default password `1952`)
 - Displays patient demographics and physicians with clickable phone numbers and map links
 - Dynamically builds a medication list with expandable details and a sticky header that updates to the selected medication
 - Responsive layout with light/dark mode using only HTML, CSS, and vanilla JavaScript
@@ -11,7 +11,7 @@ MedList is a responsive, client-side web app that displays a patient's medicatio
 ## Getting Started
 1. Clone this repository.
 2. Open `login.html` in a modern browser.
-3. Enter the password `drugBD` to view the medication list.
+3. Enter the password `1952` to view the medication list.
 4. Click any medication to expand its details; click again to collapse.
 
 ## Customization

--- a/login.js
+++ b/login.js
@@ -5,7 +5,7 @@ const errorEl = document.getElementById('error');
 form.addEventListener('submit', (e) => {
   e.preventDefault();
   const password = passwordInput.value;
-  if (password === 'thuoc1952') {
+  if (password === '1952') {
     sessionStorage.setItem('loggedIn', 'true');
     window.location.href = 'index.html';
   } else {


### PR DESCRIPTION
## Summary
- simplify login flow by setting default password to `1952` in the client-side script
- update documentation to note the new `1952` default password

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68926883ddec8331a4b1d6038e363bdc