### PR TITLE
Add upcoming appointments section with navigation link

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,6 +35,7 @@
       <ul>
         <li><a href="#patient"><i class="fas fa-user"></i> Patient Info</a></li>
         <li><a href="#physicians"><i class="fas fa-user-md"></i> Physician Info</a></li>
+        <li><a href="#appointments-section"><i class="far fa-calendar-alt"></i> Appointments</a></li>
         <li>
           <a href="#medications"><i class="fas fa-pills"></i> Medications</a>
         </li>
@@ -51,6 +52,7 @@
 
       <section id="patient"></section>
       <section id="physicians"></section>
+      <section id="appointments-section"></section>
       <section id="medications">
         <h2><i class="fas fa-pills"></i> Medications</h2>
         <ul id="med-list" class="med-list"></ul>

--- a/script.js
+++ b/script.js
@@ -25,6 +25,33 @@ const physicians = [
   },
 ];
 
+const appointments = [
+  {
+    name: "Lincoln Jimenez",
+    date: "Thu, Aug 21, 2025 03:00 PM",
+    reason: "Transsphenoidal resection pituitary mass with no images",
+    location: "HCA Florida West Neurosurgical Specialists",
+    address: "2120 E Johnson Ave, Ste 106, Pensacola, FL 325146091",
+    phone: "(850)555-0101",
+  },
+  {
+    name: "Edward Schuka",
+    date: "Mon, Aug 18, 2025 02:30 PM",
+    reason: "Non Traumatic Brain Injury - pt in WFH discharged 07/28",
+    location: "HCA Florida West Primary Care - Nine Mile Rd",
+    address: "1190 E Nine Mile Rd, Pensacola, FL 325141651",
+    phone: "(850)555-0102",
+  },
+  {
+    name: "Lauren Knierim",
+    date: "Tue, Sep 9, 2025 03:00 PM",
+    reason: "CC 6M POST WM",
+    location: "HCA Florida West Cardiology Specialists - Pensacola",
+    address: "8333 N Davis Hwy FL 4, Pensacola, FL 325146050",
+    phone: "(850)555-0103",
+  },
+];
+
 const medications = [
   {
     number: 1,
@@ -205,6 +232,61 @@ function renderPhysicians() {
   el.innerHTML = html;
 }
 
+function createICS(appt) {
+  const start = new Date(appt.date);
+  const end = new Date(start.getTime() + 30 * 60000);
+  const pad = (n) => String(n).padStart(2, '0');
+  const format = (d) =>
+    `${d.getUTCFullYear()}${pad(d.getUTCMonth() + 1)}${pad(d.getUTCDate())}T${pad(
+      d.getUTCHours()
+    )}${pad(d.getUTCMinutes())}00Z`;
+  const ics = `BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nSUMMARY:${appt.reason}\nDTSTART:${format(
+    start
+  )}\nDTEND:${format(end)}\nLOCATION:${appt.address}\nEND:VEVENT\nEND:VCALENDAR`;
+  return URL.createObjectURL(new Blob([ics], { type: 'text/calendar' }));
+}
+
+function checkIn(name) {
+  console.log(`Check-In stub for ${name}`);
+}
+
+function renderAppointments() {
+  const el = document.getElementById('appointments-section');
+  let html =
+    "<h2><i class='far fa-calendar-alt'></i> Upcoming Appointments</h2>";
+  appointments.forEach((appt, idx) => {
+    const tel = `tel:${appt.phone.replace(/[^+\d]/g, '')}`;
+    const icsUrl = createICS(appt);
+    html += `
+      <div class="appointment-card">
+        <div class="appointment-header">
+          <div class="profile-icon">${appt.name.charAt(0)}</div>
+          <div class="appointment-main">
+            <h3 class="appointment-name">${appt.name}</h3>
+            <p class="appointment-datetime">${appt.date}</p>
+          </div>
+          <a href="${tel}" class="phone-link" aria-label="Call"><i class="fas fa-phone"></i></a>
+        </div>
+        <p class="appointment-reason">${appt.reason}</p>
+        <p class="appointment-location">${appt.location}</p>
+        <p class="appointment-address">${appt.address}</p>
+        <img src="https://via.placeholder.com/400x200?text=Map" alt="Map snapshot" class="map-snapshot">
+        <div class="appointment-actions">
+          <a href="${icsUrl}" download="appointment-${idx + 1}.ics" class="calendar-link" aria-label="Add to Calendar"><i class="far fa-calendar-plus"></i></a>
+          <button class="check-in-btn" data-name="${appt.name}">Check-In</button>
+        </div>
+        <textarea class="appointment-notes" placeholder="Notes..."></textarea>
+      </div>
+    `;
+  });
+  el.innerHTML = html;
+  el.querySelectorAll('.check-in-btn').forEach((btn) => {
+    btn.addEventListener('click', (e) => {
+      checkIn(e.target.dataset.name);
+    });
+  });
+}
+
 function renderMedications() {
   const list = document.getElementById('med-list');
   list.innerHTML = '';
@@ -353,6 +435,7 @@ function initUI() {
 document.addEventListener('DOMContentLoaded', () => {
   renderPatient();
   renderPhysicians();
+  renderAppointments();
   renderMedications();
   initUI();
 });

--- a/styles.css
+++ b/styles.css
@@ -415,6 +415,88 @@ body.light-mode {
   white-space: nowrap;
 }
 
+/* Appointment cards */
+#appointments-section {
+  margin-bottom: 1.5rem;
+}
+
+.appointment-card {
+  background: var(--card-bg);
+  border-radius: 12px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+  padding: 1rem;
+  margin-bottom: 1rem;
+}
+
+.appointment-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.profile-icon {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: #ccc;
+  color: #333;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.phone-link {
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--accent-light);
+}
+
+.map-snapshot {
+  border-radius: 8px;
+  margin: 0.5rem 0;
+}
+
+.appointment-actions {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 1rem;
+  margin-top: 0.5rem;
+}
+
+.check-in-btn {
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.check-in-btn:hover {
+  background: var(--accent-light);
+}
+
+.calendar-link {
+  color: var(--accent-light);
+  font-size: 1.25rem;
+}
+
+.appointment-notes {
+  margin-top: 0.5rem;
+  padding: 0.5rem;
+  border-radius: 4px;
+  border: 1px solid var(--accent-light);
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--text-color);
+}
+
 @media (prefers-color-scheme: dark) {
   body {
     background: linear-gradient(135deg, #0d47a1, #006064);


### PR DESCRIPTION
## Summary
- Add "Appointments" link to navigation and new `appointments-section` container on the patient portal home page.
- Introduce mock appointment data, rendering logic with phone links, calendar downloads, and check-in stub.
- Style appointment cards with rounded borders, shadows, and responsive layout.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893e36daf788331a65f1c1b4614a5b8