### PR TITLE
feat: add collapsible appointments section

### DIFF
--- a/script.js
+++ b/script.js
@@ -50,7 +50,17 @@ const appointments = [
     address: "8333 N Davis Hwy FL 4, Pensacola, FL 325146050",
     phone: "(850)555-0103",
   },
+  {
+    name: "Mary Johnson",
+    date: "Wed, Jan 1, 2025 11:00 AM",
+    reason: "Routine check-up",
+    location: "HCA Florida West Outpatient Clinic",
+    address: "1000 Medical Pkwy, Pensacola, FL 32514",
+    phone: "(850)555-0104",
+  },
 ];
+
+appointments.sort((a, b) => new Date(a.date) - new Date(b.date));
 
 const medications = [
   {
@@ -251,36 +261,73 @@ function checkIn(name) {
 }
 
 function renderAppointments() {
-  const el = document.getElementById('appointments-section');
-  let html =
-    "<h2><i class='far fa-calendar-alt'></i> Upcoming Appointments</h2>";
+  const section = document.getElementById('appointments-section');
+
+  const wrapper = document.createElement('details');
+  wrapper.className = 'appointments-wrapper';
+  wrapper.open = true;
+
+  const summary = document.createElement('summary');
+  summary.className = 'collapse-summary';
+  summary.innerHTML = "<i class='far fa-calendar-alt'></i> Upcoming Appointments";
+  wrapper.appendChild(summary);
+
   appointments.forEach((appt, idx) => {
-    const tel = `tel:${appt.phone.replace(/[^+\d]/g, '')}`;
-    const icsUrl = createICS(appt);
-    html += `
-      <div class="appointment-card">
-        <div class="appointment-header">
-          <div class="profile-icon">${appt.name.charAt(0)}</div>
-          <div class="appointment-main">
-            <h3 class="appointment-name">${appt.name}</h3>
-            <p class="appointment-datetime">${appt.date}</p>
+    const card = document.createElement('details');
+    card.className = 'appointment-card';
+
+    const cardSummary = document.createElement('summary');
+    cardSummary.className = 'collapse-summary';
+
+    const header = document.createElement('div');
+    header.className = 'appointment-header';
+
+    const icon = document.createElement('div');
+    icon.className = 'profile-icon';
+    icon.textContent = appt.name.charAt(0);
+
+    const main = document.createElement('div');
+    main.className = 'appointment-main';
+    main.innerHTML = `<h3 class="appointment-name">${appt.name}</h3><p class="appointment-datetime">${appt.date}</p>`;
+
+    const phoneLink = document.createElement('a');
+    phoneLink.href = `tel:${appt.phone.replace(/[^+\d]/g, '')}`;
+    phoneLink.className = 'phone-link';
+    phoneLink.setAttribute('aria-label', 'Call');
+    phoneLink.innerHTML = '<i class="fas fa-phone"></i>';
+    phoneLink.addEventListener('click', (e) => e.stopPropagation());
+
+    header.appendChild(icon);
+    header.appendChild(main);
+    header.appendChild(phoneLink);
+    cardSummary.appendChild(header);
+    card.appendChild(cardSummary);
+
+    const details = document.createElement('div');
+    details.className = 'appointment-details';
+
+    const mapQuery = encodeURIComponent(appt.address.replace(/<br>/g, ' '));
+    const addressLink = `<a href="https://maps.google.com/?q=${mapQuery}" target="_blank" rel="noopener noreferrer">${appt.address}</a>`;
+
+    details.innerHTML = `
+          <p class="appointment-reason">${appt.reason}</p>
+          <p class="appointment-location">${appt.location}</p>
+          <p class="appointment-address">${addressLink}</p>
+          <iframe src="https://maps.google.com/maps?q=${mapQuery}&output=embed" class="map-snapshot" frameborder="0" allowfullscreen></iframe>
+          <div class="appointment-actions">
+            <a href="${createICS(appt)}" download="appointment-${idx + 1}.ics" class="calendar-link" aria-label="Add to Calendar"><i class="far fa-calendar-plus"></i></a>
+            <button class="check-in-btn" data-name="${appt.name}">Check-In</button>
           </div>
-          <a href="${tel}" class="phone-link" aria-label="Call"><i class="fas fa-phone"></i></a>
-        </div>
-        <p class="appointment-reason">${appt.reason}</p>
-        <p class="appointment-location">${appt.location}</p>
-        <p class="appointment-address">${appt.address}</p>
-        <img src="https://via.placeholder.com/400x200?text=Map" alt="Map snapshot" class="map-snapshot">
-        <div class="appointment-actions">
-          <a href="${icsUrl}" download="appointment-${idx + 1}.ics" class="calendar-link" aria-label="Add to Calendar"><i class="far fa-calendar-plus"></i></a>
-          <button class="check-in-btn" data-name="${appt.name}">Check-In</button>
-        </div>
-        <textarea class="appointment-notes" placeholder="Notes..."></textarea>
-      </div>
-    `;
+          <textarea class="appointment-notes" placeholder="Notes..."></textarea>
+        `;
+    card.appendChild(details);
+    wrapper.appendChild(card);
   });
-  el.innerHTML = html;
-  el.querySelectorAll('.check-in-btn').forEach((btn) => {
+
+  section.innerHTML = '';
+  section.appendChild(wrapper);
+
+  section.querySelectorAll('.check-in-btn').forEach((btn) => {
     btn.addEventListener('click', (e) => {
       checkIn(e.target.dataset.name);
     });

--- a/styles.css
+++ b/styles.css
@@ -420,12 +420,43 @@ body.light-mode {
   margin-bottom: 1.5rem;
 }
 
+.appointments-wrapper {
+  background: var(--card-bg);
+  border-left: 4px solid var(--accent);
+  border-radius: 6px;
+  line-height: 1.6;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+.appointments-wrapper > .collapse-summary {
+  padding: 0.75rem 1rem;
+  background: #e3f2fd;
+  color: var(--accent);
+  cursor: pointer;
+}
+
+.appointments-wrapper > .collapse-summary:hover {
+  background: #bbdefb;
+}
+
 .appointment-card {
   background: var(--card-bg);
   border-radius: 12px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+  margin: 1rem;
+  overflow: hidden;
+}
+
+.appointment-card > .collapse-summary {
   padding: 1rem;
-  margin-bottom: 1rem;
+}
+
+.appointment-card > .collapse-summary:hover {
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.appointment-details {
+  padding: 0 1rem 1rem;
 }
 
 .appointment-header {
@@ -433,6 +464,7 @@ body.light-mode {
   align-items: center;
   justify-content: space-between;
   gap: 0.5rem;
+  flex: 1;
 }
 
 .profile-icon {
@@ -458,8 +490,12 @@ body.light-mode {
 }
 
 .map-snapshot {
+  width: 100%;
+  max-width: 200px;
+  height: 200px;
   border-radius: 8px;
   margin: 0.5rem 0;
+  border: none;
 }
 
 .appointment-actions {
@@ -600,6 +636,10 @@ body.light-mode {
 
   .physician-map iframe {
     height: 150px;
+  }
+  .map-snapshot {
+    height: 150px;
+    max-width: 100%;
   }
 }
 


### PR DESCRIPTION
## Summary
- nest upcoming appointments inside a collapsible section with individual collapsible cards
- sort upcoming appointments chronologically starting with a New Year's visit
- build appointment cards with DOM elements and open wrapper by default so collapsible items are visible
- standardize appointment map snapshots to match physician map dimensions for consistent layout
- embed Google Maps in each appointment card and link addresses to open in Google Maps

## Testing
- `node --check script.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893ef22fa9483319ac56535c0086424